### PR TITLE
fix: update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install stridejs
 ⚡️ For web interfaces, we recommend using [cosmos-kit](https://github.com/cosmology-tech/cosmos-kit). To sign and broadcast messages, you can create signers with a variety of options:
 
 - [cosmos-kit](https://github.com/cosmology-tech/cosmos-kit/tree/main/packages/react#signing-clients) (recommended)
-- [keplr](https://docs.keplr.app/api/cosmjs.html)
+- [keplr](https://docs.keplr.app/api/use-with/cosmjs)
 - [cosmjs](https://gist.github.com/webmaster128/8444d42a7eceeda2544c8a59fbd7e1d9)
 
 ### Initializing the Stargate Client


### PR DESCRIPTION
Hi! I fixes a dead link in the `README.md` file. The old link pointed to a non-existent page for the Keplr CosmJS documentation. It has been updated to the correct and current URL.