### PR TITLE
chore: fixed incorrect git clone log

### DIFF
--- a/scripts/clone_repos.ts
+++ b/scripts/clone_repos.ts
@@ -37,7 +37,7 @@ for (const repoConfig of config) {
   const { repo, rev } = repoConfig;
 
   try {
-    console.log(`git clone ${repo}@${rev}`);
+    console.log(`git clone --branch ${rev} ${repo}`);
 
     execSync(
       `cd "${reposDir}" && git clone --depth 1 --branch "${rev}" "${repo}" 2> /dev/null`,


### PR DESCRIPTION
Noticed that the log message `console.log(\`git clone ${repo}@${rev}\`);` didn’t match the actual command executed via `execSync`.  

While it’s not a critical issue, the log could be misleading since `git clone https://github.com/repo@branch` is not a valid syntax. Updated the log to reflect the correct command using `--branch "${rev}"`.